### PR TITLE
[tokenized-card] experiment with tokenized payments

### DIFF
--- a/src/OrderSummary.js
+++ b/src/OrderSummary.js
@@ -78,11 +78,21 @@ async function doPaymentRequest() {
     .reduce((accumulator, items) => accumulator.concat(items), [])
     .reduce(typeSplitter, undefined);
   const total = this.sumTotal();
-  const methodData = [
-    {
-      supportedMethods: ["basic-card"],
-    },
-  ];
+  //const methodData = [
+  //  {
+  //    supportedMethods: ["basic-card"],
+  //  },
+  //];
+  const methodData = [{
+    supportedMethods: ['tokenized-card'],
+    data: {
+      supportedNetworks: ['mastercard','visa', 'amex', 'discover', 'jcb','unionpay'],
+      supportedTypes: ['credit','debit'],
+      usageType: 'one-time',
+      payeeID: '234987',
+      keyProviderURL: 'https://pspKeyProvider.example/tokenizedCardPublicKey',
+    }
+  }];
   const id = `super-store-order-${String(Math.random()).substr(2)}`;
   const details = {
     id,

--- a/src/PaymentRequest.js
+++ b/src/PaymentRequest.js
@@ -27,6 +27,7 @@ const defaultPaymentOptions = Object.freeze({
 export const _details = Symbol("[[details]]");
 export const _options = Symbol("[[options]]");
 export const _serializedMethodData = Symbol("[[serializedMethodData]]");
+export const _originalMethodData = Symbol("[[originalMethodDataa]]");
 export const _serializedModifierData = Symbol("[[serializedMethodData]]");
 export const _state = Symbol("[[state]]");
 export const _updating = Symbol("[[updating]]");
@@ -36,6 +37,7 @@ const _disableForm = Symbol("disableForm");
 const _acceptPromise = Symbol("[[acceptPromise]]");
 const _selectedShippingOption = Symbol("[[selectedShippingOption]]");
 const _shippingAddress = Symbol("[[shippingAddressSymbol]]");
+
 
 class PaymentRequest extends EventTarget {
   constructor(originalMethodData, originalDetails, originalOptions) {
@@ -70,6 +72,7 @@ class PaymentRequest extends EventTarget {
         serializedData
       );
     }
+
 
     // Process the total:
     if (!PaymentCurrencyAmount.isValid(details.total.amount.value)) {
@@ -109,6 +112,7 @@ class PaymentRequest extends EventTarget {
     this[_shippingAddress] = null;
     this[_selectedShippingOption] = selectedShippingOption;
     this[_response] = null;
+    this[_originalMethodData] = originalMethodData;
   }
 
   [_disableForm]() {
@@ -134,6 +138,14 @@ class PaymentRequest extends EventTarget {
   get shippingType() {
     const { shippingType } = this[_options];
     return shippingType ? shippingType : null;
+  }
+
+  get serializedMethodData() {
+    return this[_serializedMethodData];
+  }
+
+  get originalMethodData() {
+    return this[_originalMethodData];
   }
 
   /**

--- a/src/PaymentResponse.js
+++ b/src/PaymentResponse.js
@@ -36,9 +36,20 @@ export default class PaymentResponse extends EventTarget {
   get requestId() {
     return this[_request].id;
   }
+
+  get request() {
+    return this[_request];
+  }
+
   //readonly attribute DOMString methodName;
   get methodName() {
     return this[_methodName];
+  }
+
+  get keyProviderURL() {
+    var originalMethodData = this[_request].originalMethodData;
+    var matchedMethodData = originalMethodData.find(e => e.supportedMethods.includes(this[_methodName])).data;
+    return matchedMethodData.keyProviderURL;
   }
   //readonly attribute object details;
   get details() {
@@ -118,6 +129,8 @@ export default class PaymentResponse extends EventTarget {
     } finally {
       // ✅ Finally, when retryPromise settles, set response[[retrying]] to false.
       this[_retrying] = false;
+      // tokenize
+      this.tokenize();
       paymentSheet.removeEventListener(
         "payerdetailschange",
         payerDetailListener
@@ -125,6 +138,29 @@ export default class PaymentResponse extends EventTarget {
     }
     // ✅  Return retryPromise.
     return retryPromise.promise;
+  }
+
+  createTokenizationRequest() {
+    var tokenizationRequest = {};
+    return tokenizationRequest;
+  }
+
+  sendRequestToTokenProvider(request, url) {
+    var tokenProviderResponse = {
+      cardNumber: "5413339000001513",
+      expiryMonth: "12",
+      expiryYear: "20",
+      cryptogram: "AlhlvxmN2ZKuAAESNFZ4GoABFA==",
+      typeOfCryptogram: "UCAF", // "Universal Card Authentication Field"
+      trid: "59812345678",
+      eci: "242", // Authorization and final transaction request with UCAF data
+    };
+    return tokenProviderResponse;
+  }
+
+  tokenize() {
+    var response = this.sendRequestToTokenProvider(this.createTokenizationRequest(), this.keyProviderURL);
+    this.details.collectedData = response;
   }
 
   //serializer = { attribute };

--- a/src/PaymentSheet.js
+++ b/src/PaymentSheet.js
@@ -311,7 +311,8 @@ async function init(paymentSheet) {
       topWidgets.get("awaitPaymentResponse").active = true;
       priv
         .get("sessionPromise")
-        .resolve({ collectedData, methodName: "baic-card" });
+        .resolve({ collectedData, methodName: "tokenized-card" });
+        // .resolve({ collectedData, methodName: "basic-card" });
     }
   );
 }

--- a/src/datacollectors/PaymentMethodChooser.js
+++ b/src/datacollectors/PaymentMethodChooser.js
@@ -14,6 +14,36 @@ const defaultMethods = [
     ],
   },
   {
+    name: "tokenized-card",
+    value: "test1",
+    icons: [
+      {
+        src: "./payment-sheet/images/paypal.svg",
+        sizes: "256x256",
+      },
+    ],
+  },
+  {
+    name: "token-reference",
+    value: "test2",
+    icons: [
+      {
+        src: "./payment-sheet/images/paypal.svg",
+        sizes: "256x256",
+      },
+    ],
+  },
+  {
+    name: "token-cryptogram",
+    value: "test3",
+    icons: [
+      {
+        src: "./payment-sheet/images/paypal.svg",
+        sizes: "256x256",
+      },
+    ],
+  },
+  {
     name: "https://paypal.com",
     value: "paypal",
     icons: [


### PR DESCRIPTION
Based on the conversation with @marcoscaceres in August, I want to help doing some experimentation with tokenized payments. 

What we are trying to do is see if the data structures defined in the
draft spec, combined with the Payment Handler API, actually work. That
will help us determine:

 1. Can all this just be done with a Payment Handler?
 2. If no, how could we enhance "basic card" to get this to work?
 3. Are there any pieces missing from the Payment Request API?

In this PR,
(1)  I changed the supported method from basic-card to tokenized-card.
(2)  I also included additional information such as "keyProviderURL".  Then I added some code to make the data accessible from PaymentResponse.  
(3) Then I added a tokenize() function, which is supposed to send a request to token provider to get tokenProviderResponse. Here I just mocked it out.


